### PR TITLE
docs: add PyWallet attribution, third-party licenses, and normalize headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![CI](https://github.com/mystervee/Crypto-Wallet-Explorer/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/mystervee/Crypto-Wallet-Explorer/actions/workflows/ci.yml)
 
-A simple, cross-platform wallet.dat scanner for Bitcoin-family wallets. It is intended for users to scan wallet files on thier own machine to gain basic information on the contents of the wallet, balance is displayed where possible.  It tries pywallet for structured dumps when available, and safely falls back to read-only address discovery (Base58 + Bech32 + ETH 0x strings).
+A simple, cross-platform wallet.dat scanner for Bitcoin-family wallets. It is intended for users to scan wallet files on their own machine to gain basic information on the contents of the wallet; balance is displayed where possible. It tries PyWallet for structured dumps when available, and safely falls back to read-only address discovery (Base58 + Bech32 + ETH 0x strings).
 
-## features
+## Features
 - Scans folders recursively for `.dat` and skips duplicate backups by content hash
 - PyWallet integration with JSON parsing and optional WSL fallback on Windows
 - Read-only fallback detection for BTC, LTC, DOGE, PPC, GRC, and ETH
@@ -15,7 +15,7 @@ A simple, cross-platform wallet.dat scanner for Bitcoin-family wallets. It is in
 - Bech32 support for BTC (`bc1…`) and LTC (`ltc1…`)
 - CSV export including balance, dedup count, and first wallet path
 
-## usage
+## Usage
 
 From source (recommended for latest fixes):
 
@@ -23,14 +23,16 @@ Windows (PowerShell):
 
 ```powershell
 python -m venv .venv
-.# existing code...
+\.\.venv\Scripts\Activate.ps1
+python -m pip install -r requirements.txt
 ```
 
 Linux/macOS (bash):
 
 ```bash
 python3 -m venv .venv
-.# existing code...
+source .venv/bin/activate
+python -m pip install -r requirements.txt
 ```
 
 Run the scanner:
@@ -41,7 +43,7 @@ python .\Basic_Wallet_Scanner.py --dir <path-to-backups> --csv scan_results.csv
 
 From release zip (prebuilt): download the latest release, extract, create a venv, install requirements, then run the command above.
 
-## quick start
+## Quick Start
 1) Create a virtual environment and install dependencies
 
 Windows (PowerShell):
@@ -72,7 +74,7 @@ If `--dir` is omitted, the script will prompt for a folder.
 - Console output shows discovered addresses grouped by coin
 - A `scan_results.csv` is saved (by default to the current working directory)
 
-## cli flags
+## CLI Flags
 - `--dir <folder>`: Folder to scan (recursively) for `.dat`
 - `--csv <path>`: Output CSV path (default: `scan_results.csv` in CWD)
 - `--no-balances`: Skip all balance lookups
@@ -92,7 +94,7 @@ python .\Basic_Wallet_Scanner.py --dir D:\Backups\Wallets --csv D:\out\scan.csv
 python .\Basic_Wallet_Scanner.py --dir D:\Backups\Wallets --no-balances
 ```
 
-## supported coins
+## Supported Coins
 - BTC: Base58 P2PKH/P2SH, Bech32 `bc1…`
 - LTC: Base58 P2PKH/P2SH, Bech32 `ltc1…`
 - DOGE: Base58 P2PKH/P2SH
@@ -100,7 +102,7 @@ python .\Basic_Wallet_Scanner.py --dir D:\Backups\Wallets --no-balances
 - GRC (Gridcoin): Base58 P2PKH
 - ETH: Hex `0x` addresses (detection only; no balances)
 
-## output csv schema
+## Output CSV Schema
 Columns:
 - `wallet`: Source file path where the address was first seen
 - `coin`: BTC/LTC/DOGE/PPC/GRC/ETH
@@ -110,7 +112,7 @@ Columns:
 - `count`: Number of times this (coin, address) was encountered across all files
 - `first_wallet`: The first wallet file in which this address appeared
 
-## windows + wsl (pywallet fallback)
+## Windows + WSL (PyWallet Fallback)
 PyWallet needs Berkeley DB (bsddb). On Windows this is tricky; the script will auto-try WSL if a local run fails with a bsddb error.
 
 Inside WSL (Ubuntu/Debian):
@@ -122,7 +124,7 @@ sudo apt install -y python3-bsddb3
 
 No extra setup is required beyond having WSL installed; the script converts paths and invokes `python3` within WSL for the pywallet step.
 
-## testing
+## Testing
 Developer tests live in `tests/` and can be run with pytest:
 
 ```powershell
@@ -130,23 +132,23 @@ python -m pip install -r requirements-dev.txt
 pytest -q
 ```
 
-## troubleshooting
+## Troubleshooting
 - PyWallet JSON parse errors: Make sure WSL + `python3-bsddb3` is installed on Windows, or run natively on Linux.
 - Public API limits: LTC/DOGE/PPC balances use public endpoints and may rate-limit or return empty data. Rerun later or use `--no-balances`.
 - Very old/alt forks: Address version bytes vary. The fallback will label as `UNKNOWN` if it can’t map a version byte.
 - No addresses found: Some backups store keys encrypted or in non-standard formats; try the pywallet path on Linux.
 
-## security and privacy
+## Security and Privacy
 - Read-only: The scanner never writes to wallet files or transacts on any network.
 - Offline usage: For maximum privacy, run with `--no-balances` to avoid network calls; you’ll still get address discovery and CSV export.
 
-## contributing
+## Contributing
 PRs welcome for:
 - Additional coin/version mappings and bech32 checksum verification
 - More reliable balance providers and optional API key support
 - Performance improvements and better CSV/reporting options
 
-## releases
+## Releases
 Prebuilt zips are published on the GitHub Releases page when a tag like `v1.0.0` is pushed.
 
 Contents:
@@ -167,5 +169,18 @@ python -m pip install -r requirements.txt
 python .\Basic_Wallet_Scanner.py --dir D:\Backups\Wallets --csv scan_results.csv
 ```
 
-## disclaimer
+## Credits
+- PyWallet by joric — Public Domain (includes portions under MIT and Apache-2 licenses). Repository: https://github.com/joric/pywallet. We vendor `pywallet/pywallet.py` and invoke it for structured wallet dumps when available. See headers in `pywallet/pywallet.py` for details.
+
+## Third-Party Licenses
+This project vendors PyWallet (Public Domain) which itself includes components under permissive licenses:
+
+- BitcoinTools (wallet.dat handling) — MIT License — https://github.com/gavinandresen/bitcointools
+- python-ecdsa (EC_KEY implementation) — MIT License — https://github.com/warner/python-ecdsa
+- SlowAES (AES implementation) — Apache License 2.0 — https://code.google.com/p/slowaes/ (archived)
+- Bech32/SegWit reference — Copyright (c) 2017 Pieter Wuille — https://github.com/sipa/bech32
+
+See the attribution comments at the top of `pywallet/pywallet.py` for the authoritative list and license notes.
+
+## Disclaimer
 This tool is provided “as is,” without warranty of any kind. Use at your own risk.


### PR DESCRIPTION
add PyWallet attribution, third-party licenses, and normalize headings